### PR TITLE
Add checksum validation

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -2,4 +2,14 @@
 
 set -e
 
-bash <(curl -s https://codecov.io/bash) -Q "bitrise-step" -Z ${other_options}
+# Download and verify bash script
+curl -fLso codecov https://codecov.io/bash;
+VERSION=$(grep -o 'VERSION=\"[0-9\.]*\"' codecov | cut -d'"' -f2);
+for i in 1 256 512
+do
+  shasum -a $i -c --ignore-missing <(curl -s "https://raw.githubusercontent.com/codecov/codecov-bash/${VERSION}/SHA${i}SUM") ||
+  shasum -a $i -c <(curl -s "https://raw.githubusercontent.com/codecov/codecov-bash/${VERSION}/SHA${i}SUM" | grep -w "codecov")
+done
+
+# Upload coverage to Codecov
+bash ./codecov -Q "bitrise-step" -Z ${other_options}


### PR DESCRIPTION
Adds checksum validation based off of our [docs](https://docs.codecov.io/docs/about-the-codecov-bash-uploader#validating-the-bash-script)