### PR TITLE
Revert "fix: Add value options to OS"

### DIFF
--- a/step.yml
+++ b/step.yml
@@ -31,10 +31,6 @@ inputs:
         Name of the OS being used (options are "alpine" | "linux" | "macos")
       is_required: true
       is_sensitive: false
-      value_options:
-      - "alpine"
-      - "linux"
-      - "macos"
   - other_options: "-C $BITRISE_GIT_COMMIT"
     opts:
       title: Additional options for Codecov call


### PR DESCRIPTION
This reverts commit 832d713533410ffbfab9c53c7852f4bc7ad833d5.

As discussed [here](https://github.com/bitrise-io/bitrise-steplib/pull/3160#issuecomment-896438412), we do not believe that this should have a default value.