### PR TITLE
Remove gpg check from macos

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -2,11 +2,6 @@
 
 set -e
 
-# Install gpg for MacOS devices
-if [ -x "$(command -v brew)" ] && ! [ -x "$(command -v gpg)" ]; then
-  brew install gpg
-fi
-
 # Download and verify Codecov uploader
 curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import # One-time step
 curl -Os "https://uploader.codecov.io/${VERSION}/${OS}/codecov"


### PR DESCRIPTION
As per the Bitrise team, `gpg` is not pre-installed on osx builds.