### PR TITLE
fix: other_options not parsed properly

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -15,4 +15,4 @@ chmod +x codecov
 curl -H "Accept: application/json" "https://uploader.codecov.io/${OS}/${VERSION}" | grep -o '\"version\":\"v[0-9\.\_]\+\"' | head -1
 
 # Upload coverage to Codecov
-./codecov -Q "bitrise-step-3.0.0" -Z "${other_options}"
+./codecov -Q "bitrise-step-3.0.0" -Z ${other_options}


### PR DESCRIPTION
fixes https://github.com/codecov/codecov-bitrise/issues/7

double-quoting `${other_options}` was causing extra characters (namely ` `) to be inserted in front of the commit. This prevented users from uploading coverage as the commit SHA would be `+deadbeef1234567890`.