### PR TITLE
fix: change default commit env var to GIT_CLONE_COMMIT_HASH

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -15,4 +15,4 @@ chmod +x codecov
 curl -H "Accept: application/json" "https://uploader.codecov.io/${OS}/${VERSION}" | grep -o '\"version\":\"v[0-9\.\_]\+\"' | head -1
 
 # Upload coverage to Codecov
-./codecov -Q "bitrise-step-3.0.0" -Z ${other_options}
+./codecov -Q "bitrise-step-3.1.3" -Z ${other_options}

--- a/step.yml
+++ b/step.yml
@@ -38,7 +38,7 @@ inputs:
         Version of the Codecov Uploader to use (e.g. `v0.1.0_8880`)
       is_required: false
       is_sensitive: false
-  - other_options: "-C $BITRISE_GIT_COMMIT"
+  - other_options: "-C $GIT_CLONE_COMMIT_HASH"
     opts:
       title: Additional options for Codecov call
       description: |-


### PR DESCRIPTION
Mirroring the BASH variable [here](https://github.com/codecov/codecov-bash/blob/master/codecov#L715)