### PR TITLE
fix: remove pointer to trustedkeys.gpg

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -56,7 +56,7 @@ QKWiWJQF/XopkXwkyAYpyuyRMZ77oF7nuqLFnl5VVEiRo0Fwu45erebc6ccSwYZU
 -----END PGP PUBLIC KEY BLOCK-----"
 
 # Download and verify Codecov uploader
-echo "${CODECOV_PUBLIC_PGP_KEY}" | gpg --no-default-keyring --keyring trustedkeys.gpg --import # One-time step
+echo "${CODECOV_PUBLIC_PGP_KEY}" | gpg --no-default-keyring --import # One-time step
 curl -Os "https://uploader.codecov.io/${VERSION}/${OS}/codecov"
 curl -Os "https://uploader.codecov.io/${VERSION}/${OS}/codecov.SHA256SUM"
 curl -Os "https://uploader.codecov.io/${VERSION}/${OS}/codecov.SHA256SUM.sig"
@@ -74,4 +74,4 @@ curl -H "Accept: application/json" "https://uploader.codecov.io/${OS}/${VERSION}
 echo "-Z ${other_options}" "${@}"
 
 # Upload coverage to Codecov
-./codecov -Q "bitrise-step-3.3.1" -Z ${other_options} "${@}"
+./codecov -Q "bitrise-step-3.3.2" -Z ${other_options} "${@}"


### PR DESCRIPTION
fixes https://github.com/codecov/codecov-bitrise/issues/24

Forcing `trustedkeys.gpg` is causing `unknown type of key resources` errors when it should be `trustedkeys.kbx`. I think by removing the `--keyring` option, we can let the defaults do their thing. See below for documentation on `gpgv`

> If no --keyring option is given, gpgv looks for a “default” keyring named trustedkeys.kbx (preferred) or trustedkeys.gpg in the home directory of GnuPG, either the default home directory or the one set by the --homedir option or the GNUPGHOME environment variable. If any --keyring option is used, gpgv will not look for the default keyring. The --keyring option may be used multiple times and all specified keyrings will be used together.

[source](https://www.gnupg.org/documentation/manuals/gnupg/gpgv.html)