### PR TITLE
fix: update gpg and ditch gpgv

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -56,11 +56,11 @@ QKWiWJQF/XopkXwkyAYpyuyRMZ77oF7nuqLFnl5VVEiRo0Fwu45erebc6ccSwYZU
 -----END PGP PUBLIC KEY BLOCK-----"
 
 # Download and verify Codecov uploader
-echo "${CODECOV_PUBLIC_PGP_KEY}" | gpg --no-default-keyring --keyring trustedkeys.kbx --import # One-time step
+echo "${CODECOV_PUBLIC_PGP_KEY}" | gpg --no-default-keyring --import # One-time step
 curl -Os "https://uploader.codecov.io/${VERSION}/${OS}/codecov"
 curl -Os "https://uploader.codecov.io/${VERSION}/${OS}/codecov.SHA256SUM"
 curl -Os "https://uploader.codecov.io/${VERSION}/${OS}/codecov.SHA256SUM.sig"
-gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
+gpg --verify codecov.SHA256SUM.sig codecov.SHA256SUM
 shasum -a 256 -c codecov.SHA256SUM
 
 chmod +x codecov


### PR DESCRIPTION
`gpgv==2.4.3` is causing problems by not being able to properly find the keyring produced by `gpg`. `gpg==2.4.3` on the other hand is not allowing the `trustedkeys.kbx` file from being created.

As a result, we are ditching the `gpgv` wrapper and using `gpg`. 